### PR TITLE
Correcting rules for import API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,8 +37,8 @@ var Mixpanel = module.exports = integration('Mixpanel')
 
 Mixpanel.ensure(function(msg, settings){
   var age = Date.now() - msg.timestamp();
-  if (age > ms('5y')) {
-    return this.invalid('message.timestamp() must be within the last five years.');
+  if (age > ms('5d')) {
+    return this.invalid('message.timestamp() must be within the last five days.');
   }
   if (settings.apiKey) return;
   if ('track' != msg.type()) return;


### PR DESCRIPTION
Mixpanel import API used for all data older than 5 days (not years) per their docs: https://mixpanel.com/docs/api-documentation/importing-events-older-than-5-days