### PR TITLE
allow bypassing of last seen when tracking revenue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,8 +66,7 @@ Mixpanel.prototype.identify = function(identify, fn){
   var ignoreIp = identify.proxy('context.ignoreIp')  // TODO: remove
     || identify.proxy('context.Mixpanel.ignoreIp');
 
-  var ignoreTime = identify.proxy('context.ignoreTime') // TODO: remove
-    || identify.proxy('context.Mixpanel.ignoreTime')
+  var ignoreTime = identify.proxy('context.Mixpanel.ignoreTime')
     || !identify.active();
 
   // Default querystring and payload data shared across all calls
@@ -576,7 +575,7 @@ function formatMobileSpecific(track) {
  */
 
 function formatRevenue(track, settings){
-  return {
+  var ret = {
     $distinct_id: track.userId() || track.sessionId(),
     $token: settings.token,
     $ip: track.ip(),
@@ -587,6 +586,10 @@ function formatRevenue(track, settings){
       }
     }
   };
+  // don't flag as last seen by default
+  var ignoreTime = !track.active();
+  if (ignoreTime) ret.$ignore_time = ignoreTime;
+  return ret;
 }
 
 /**

--- a/test/fixtures/track-ignore-time-with-revenue.json
+++ b/test/fixtures/track-ignore-time-with-revenue.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "999999",
+    "event": "Purchased a lambo",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 17.38
+    },
+    "context": {
+      "ip": "10.0.0.1",
+      "active": false
+    }
+  },
+  "output": {
+    "$ip": "10.0.0.1",
+    "$append": {
+      "$transactions": {
+        "$time": 1388534400,
+        "$amount": 17.38
+      } 
+    },
+    "$token": "50912cd33fd82225ab5ae1c563bd5a7e",
+    "$distinct_id": "999999",
+    "$ignore_time": true 
+  }
+}
+
+

--- a/test/fixtures/track-revenue.json
+++ b/test/fixtures/track-revenue.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "999999",
+    "event": "Purchased a lambo",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 17.38
+    },
+    "context": {
+      "ip": "10.0.0.1" 
+    }
+  },
+  "output": {
+    "$ip": "10.0.0.1",
+    "$append": {
+      "$transactions": {
+        "$time": 1388534400,
+        "$amount": 17.38
+      } 
+    },
+    "$token": "50912cd33fd82225ab5ae1c563bd5a7e",
+    "$distinct_id": "999999"
+  }
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -146,6 +146,52 @@ describe('Mixpanel', function(){
         });
     });
 
+    it('should send revenue correctly', function(done){
+      var json = test.fixture('track-revenue');
+      var timestamp = json.input.timestamp = new Date();
+      json.output.$append.$transactions.$time = timestamp.toISOString().slice(0,19);
+      
+      var suite = test
+        .requests(2) // total number of requests
+        .set(settings)
+        .set({ people: false })
+        .track(json.input);
+
+      suite
+        .request(1) // second request
+        .query({ verbose: '1' })
+        .query({ ip: '0' })
+        .query('data', json.output, decode)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+
+    it('should not send last seen with revenue if active flag is false', function(done){
+      var json = test.fixture('track-ignore-time-with-revenue');
+      var timestamp = json.input.timestamp = new Date();
+      json.output.$append.$transactions.$time = timestamp.toISOString().slice(0,19);
+      
+      var suite = test
+        .requests(2) // total number of requests
+        .set(settings)
+        .set({ people: false })
+        .track(json.input);
+
+      suite
+        .request(1) // second request
+        .query({ verbose: '1' })
+        .query({ ip: '0' })
+        .query('data', json.output, decode)
+        .end(function(err, res){
+          if (err) return done(err);
+          assert.equal(200, res[0].status);
+          done();
+        });
+    });
+
     it('should send track with context correctly', function(done){
       var json = test.fixture('track-context');
       test
@@ -163,10 +209,12 @@ describe('Mixpanel', function(){
         });
     });
 
+    // TODO: why are these tests not checking output payload?
     it('should be able to track correctly', function(done){
       mixpanel.track(helpers.track(), done);
     });
 
+    // TODO: why are these tests not checking output payload?
     it('should be able to track a bare call', function(done){
       mixpanel.track(helpers.track.bare(), done);
     });


### PR DESCRIPTION
This fixes https://segment.atlassian.net/browse/INT-157

Previously we were not respecting the `context.active` flag which is used to bypass the automatic mixpanel tagging of "last seen" trait of a given user. We're going to bring that same chain of logic when we track `revenue`. 

Since both `.identify()` and [tracking revenue](https://mixpanel.com/help/reference/http#tracking-revenue) hits the same `engage` endpoint, we can safely assume that you can also set the same flag. 

The issue was that when `revenue` property is sent via `.track()`, it updates the 'last seen' flag for that user.

@thehydroimpulse @f2prateek @wcjohnson11 

EDIT: fyi -- there were no existing tests for tracking revenue itself so I also added a test for that