### PR TITLE
Update for parity with analytics.js integration INT-568

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -517,11 +517,13 @@ function formatUserAgent(data){
 
   if (browser) {
     ret.$browser = browser.name;
-    var match = browser.version.match(/^(\d+(\.\d+)?)/);
-    if (match) {
-      ret.$browser_version = parseFloat(match[1]);
-    } else {
-      ret.$browser_version = browser.version;
+    if (browser.version) {
+      var match = browser.version.match(/^(\d+(\.\d+)?)/);
+      if (match) {
+        ret.$browser_version = parseFloat(match[1]);
+      } else {
+        ret.$browser_version = browser.version;
+      }
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,13 +9,14 @@ var parse = require('ua-parser-js');
 var object = require('obj-case');
 var time = require('unix-time');
 var extend = require('extend');
-var each = require('lodash.foreach');
+var each = require('lodash/forEach');
 var reject = require('reject');
 var Batch = require('batch');
 var tick = setImmediate;
 var ms = require('ms');
 var is = require('is');
 var dates = require('convert-dates');
+var pickBy = require('lodash/pickBy');
 
 /**
  * Expose `Mixpanel`
@@ -83,9 +84,20 @@ Mixpanel.prototype.identify = function(identify, fn){
     verbose: 1        // make sure that we get a valid response
   };
 
+  var traits = formatTraits(identify);
+
+  if (!this.settings.setAllTraitsByDefault) {
+    var peopleProperties = (this.settings.peopleProperties || []).map(function(key) {
+      return (object.find(traitAliases, key) || key).toLowerCase();
+    });
+    traits = pickBy(traits, function(value, key) {
+      return peopleProperties.indexOf(key.toLowerCase()) !== -1;
+    });
+  }
+
   // $set must be a separate call than $union
   batch.push(function(fn){
-    var payload = extend({ $set: formatTraits(identify) }, basePayload);
+    var payload = extend({ $set: traits }, basePayload);
     var query = extend({ data: b64encode(payload) }, baseQuery);
 
     self
@@ -505,7 +517,17 @@ function formatUserAgent(data){
 
   if (browser) {
     ret.$browser = browser.name;
-    ret.$browser_version = browser.version;
+    var match = browser.version.match(/^(\d+(\.\d+)?)/);
+    if (match) {
+      ret.$browser_version = parseFloat(match[1]);
+    } else {
+      ret.$browser_version = browser.version;
+    }
+  }
+
+  if (os) {
+    ret.$os = os.name;
+    ret.$os_version = os.version;
   }
 
   return ret;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "convert-dates": "^0.1.1",
     "extend": "^3.0.0",
     "is": "^3.1.0",
-    "lodash.foreach": "^4.2.0",
+    "lodash": "^4.16.1",
     "ms": "^0.6.2",
     "obj-case": "^0.2.0",
     "reject": "0.0.1",
@@ -31,8 +31,8 @@
     "jscs": "1.x",
     "merge-util": "^0.1.0",
     "mocha": "2.x",
-    "segmentio-facade": "2.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-facade": "^3.1.0",
+    "segmentio-integration-tester": "^2.0.3",
     "should": "4.x",
     "uid": "0.0.2"
   }

--- a/test/fixtures/identify-filter-properties.json
+++ b/test/fixtures/identify-filter-properties.json
@@ -1,0 +1,35 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "timestamp": "XXX_GETS_OVERRIDDEN: See spec for details",
+    "traits": {
+      "company": "Example",
+      "firstName": "han",
+      "lastName": "kim",
+      "met": "2014-01-01",
+      "created": "2013-01-01",
+      "phone": "555555",
+      "email": "jd@example.com",
+      "trait": "some-trait"
+    },
+    "context": {
+      "ip": "0.0.0.0"
+    }
+  },
+  "output": {
+    "$distinct_id": "user-id",
+    "$token": "50912cd33fd82225ab5ae1c563bd5a7e",
+    "$time": "XXX_GETS_OVERRIDDEN: See spec for details",
+    "$set": {
+      "$first_name": "han",
+      "met": "2014-01-01T00:00:00.000Z",
+      "$created": "2013-01-01T00:00:00",
+      "$email": "jd@example.com",
+      "id": "user-id"
+    },
+    "$ip": "0.0.0.0",
+    "$ignore_time": false,
+    "mp_lib": "Segment: unknown"
+  }
+}

--- a/test/fixtures/track-context-browser.json
+++ b/test/fixtures/track-context-browser.json
@@ -13,14 +13,10 @@
     },
     "context": {
       "ip": "10.0.0.1",
-      "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.7 Safari/534.11",
-      "os": {
-        "name": "iPhone OS",
-        "version": "8.1.3"
-      },
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.101 Safari/537.36",
       "library": {
         "name": "analytics.js",
-        "version": "2.11.1"
+        "version": "3.1.0"
       }
     }
   },
@@ -29,10 +25,10 @@
     "properties": {
       "$search_engine": "google",
       "$referrer": "someone",
-      "$browser": "Safari",
-      "$os": "iPhone OS",
-      "$os_version": "8.1.3",
-      "$browser_version": 7.1,
+      "$browser": "Chrome",
+      "$os": "Mac OS",
+      "$os_version": "10.11.2",
+      "$browser_version": 53,
       "$username": "jd",
       "email": "jd@example.com",
       "mp_name_tag": "999999",

--- a/test/fixtures/track-context.json
+++ b/test/fixtures/track-context.json
@@ -72,7 +72,7 @@
   },
   "output": {
     "event": "HELLO6",
-    "properties": { 
+    "properties": {
       "$app_release": "3.0.1.545",
       "$app_version": "545",
       "$current_url": "https://segment.com/academy/",
@@ -84,7 +84,7 @@
       "token": "50912cd33fd82225ab5ae1c563bd5a7e",
       "mp_name_tag": "999999",
       "$browser": "Mobile Safari",
-      "$browser_version": "9.0",
+      "$browser_version": 9,
       "$carrier": "T-Mobile NL",
       "$manufacturer": "Apple",
       "$model": "iPhone7,2",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,8 +1,6 @@
 
 var facade = require('segmentio-facade');
 var merge = require('merge-util');
-var join = require('path').join;
-var assert = require('assert');
 var uid = require('uid');
 
 /**
@@ -13,71 +11,6 @@ var firstId  = uid();
 var secondId = uid();
 var groupId  = uid();
 var email = 'testing-' + firstId + '@segment.io';
-
-/**
- * Mapper tester.
- *
- * @param {String} dirname
- * @return {Function}
- */
-
-exports.mapper = function(dirname){
-  assert(dirname, '__dirname must be supplied');
-  dirname = join(dirname, 'fixtures');
-  return function(integration){
-    integration.fixture = function(name, settings){
-      var dir = join(dirname, name + '.json');
-      var json = require(dir);
-      var input = json.input;
-      var output = json.output;
-      var type = input.type[0].toUpperCase() + input.type.slice(1);
-      var Type = facade[type];
-      var map = integration.mapper[input.type];
-      var mapped = map.call(integration, new Type(input), settings || {});
-      mapped = JSON.parse(JSON.stringify(mapped)); // dates
-      mapped.should.eql(output);
-    };
-  };
-};
-
-/**
- * Create ecommerce transaction.
- *
- * @param {Object} options
- * @return {Track}
- */
-
-exports.transaction = function(options){
-  return new facade.Track(merge({
-    userId: firstId,
-    channel: 'server',
-    timestamp: new Date,
-    event: 'Completed Order',
-    properties: {
-      orderId: 't-39a224df',
-      total: 99.99,
-      shipping: 13.99,
-      tax: 20.99,
-      products: [{
-        quantity: 1,
-        price: 24.75,
-        name: 'Sony Pulse',
-        sku: 'p-957c416f',
-        category: 'Entertainment'
-      }, {
-        quantity: 3,
-        price: 24.75,
-        name: 'Sony PS3',
-        sku: 'p-5bd14e17',
-        category: 'Entertainment'
-      }]
-    },
-    options: {
-      ip: '4.184.68.0',
-      userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
-    }
-  }, options));
-};
 
 /**
  * Create a track call merged from `options`
@@ -179,94 +112,4 @@ exports.identify = function (options) {
     timestamp : new Date(),
     channel : 'server'
   }, options));
-};
-
-/**
- * Create a page call merged from `options`
- *
- * @param {Object} options
- * @return {Page}
- */
-
-exports.page = function(options){
-  return new facade.Page(merge({
-    userId: firstId,
-    name: 'Docs',
-    category: 'Support',
-    properties: {
-      url: 'https://segment.io/docs',
-      title: 'Analytics.js - Segment.io'
-    },
-    context: {
-      ip: '12.212.12.49'
-    },
-    timestamp: new Date,
-    channel: 'server'
-  }, options || {}));
-};
-
-/**
- * Create a screen call merged from `options`
- *
- * @param {Object} options
- * @return {Page}
- */
-
-exports.screen = function(options){
-  return new facade.Screen(merge({
-    userId: firstId,
-    name: 'Login',
-    category: 'Authentication',
-    properties: {
-      type: 'Facebook'
-    },
-    context: {
-      ip: '12.212.12.49'
-    },
-    timestamp: new Date,
-    channel: 'server'
-  }, options || {}));
-};
-
-/**
- * Create a group call merged from `options`
- *
- * @param {Object} options
- * @return {Group}
- */
-
-exports.group = function(options){
-  return new facade.Group(merge({
-    groupId: groupId,
-    userId: firstId,
-    traits: {
-      email: email,
-      name: 'Segment.io',
-      state: 'CA',
-      city: 'San Francisco',
-      created: new Date('2/1/2014'),
-      plan: 'Enterprise',
-    },
-    context: {
-      ip: '12.212.12.49'
-    },
-    timestamp: new Date,
-    channel: 'server'
-  }, options || {}));
-};
-
-/**
- * Create an alias call merged from `options`
- *
- * @param {Object} options
- * @return {Alias}
- */
-
-exports.alias = function (options) {
-  return new facade.Alias(merge({
-    from      : firstId,
-    to        : secondId,
-    channel   : 'server',
-    timestamp : new Date()
-  }, options || {}));
 };


### PR DESCRIPTION
The mixpanel library sends browser version as a number parsed from `major.minor`. In addition, it sends the OS parsed from the useragent. The server-side integration will now send the same, but the OS will be overwritten by `context.os`, which is sent from the mobile libraries.
